### PR TITLE
Put draft of vacancy on webpages

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -99,6 +99,12 @@ documentation:
      - Python package to import magnetometry data and calculate extrinsic magnetic properties
 
 
+Current vacancies
+-----------------
+
+One upcoming `open position at MPSD in Hamburg <open-positions.html>`__ (September 2025).
+
+
 Further information
 -------------------
 

--- a/source/open-positions.rst
+++ b/source/open-positions.rst
@@ -1,4 +1,74 @@
 Open positions
 ==============
 
-There are no open positions at the moment.
+Preview: Computational Scientist at MPSD (Hamburg, Germany)
+--------------------------------------------------------------------
+
+Overview
+~~~~~~~~
+
+- Computational Scientists
+- Starting date: as soon as possible
+- The appointment is for up 24 months, starting as soon as possible, ending December 2027
+- The screening of applications and interviews will start from 10 October 2025
+- The application link and final advert will be published soon.
+
+More detailed description (Draft)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Max Planck Society is Germany's premier research organisation. The currently 86 Max Planck Institutes and facilities conduct basic research in the service of the general public in the natural sciences, life sciences, social sciences and the humanities.
+
+The Max Planck Institute for the Structure and Dynamics of Matter (MPSD) is located at the Science Campus Hamburg-Bahrenfeld and investigates dynamical phenomena within matter down to the elementary timescales of atomic and electronic motions, the femtosecond or attosecond timescale. The focus is on the use of short wavelength ultrafast probes, such as X-rays or electron pulses, which are capable of measuring atomic and electronic structures in matter of all kinds.
+
+For the project "Software Engineering for Magnetic Materials Modelling- (MaMMoS project)" we are looking for one
+
+**Computational Scientists (f/m/x)**
+
+**Starting date: as soon as possible**
+
+The Magnetic Multiscale Modelling Suite (MaMMoS) project (https://mammos-project.github.io/), funded by the European Commission [1], aims to pioneer advancements in magnetic materials research and development essential for energy, communication, and information technologies, and in particular support the green deal [2], i.e. the green transition, with the ultimate goal of reaching climate neutrality by 2050. By leveraging characterisation, multiscale modelling, machine learning, and numerical optimisation, the project seeks to craft a magnetic multiscale modelling suite to innovatively design and fine-tune magnetic materials, and devices and products based on magnetic materials. Central to the project are the collaboration with industry partners producing products with magnetic components, the integration of artificial intelligence (AI) for optimising simulation and experimental data, and the creation of open-source software tools.
+
+The successful candidate will be part of the MaMMoS team at MPSD in Hamburg. MPSD is leading the research software engineering activities for the project. Close collaboration with project partners in multiscale modelling, characterisation, machine learning, and industrial design will be essential to integrate all data and methodology, and to define appropriate data and metadata standards, application interfaces and user interfaces. The software activities need to design, implement and make open source the framework for the multi-scale modelling. Alongside this, close collaboration takes place with the Max Planck Computing and Data Facility in Garching to develop and implement cutting-edge AI/machine learning (ML) models for data prediction and rectification of systematic simulation inaccuracies.
+
+The skills required for this project are broad, and we do not expect any single person to fulfil all requirements. Training on the job will be provided by world-leading experts at the respective institutions and the project partner sites.
+
+Key Responsibilities:
+- Design, development, and implementation of the MaMMoS software framework
+- Collaborate in ML/AI model research to support modelling, characterisation and product design
+- Engage in creation of suitable data standards to reduce data engineering efforts, in close collaboration with domain experts who capture the data or need to use it
+- Collaborate effectively within an interdisciplinary team and with EU magnet industry partners
+- Engage in outreach activities for the wider public and domain experts, including training for potential users of the open source MaMMoS software and standards
+- With project partners, engage in multi-scale modelling of magnetic materials, bridging gaps from first principles simulations to device-level simulators
+- Travel regularly to project meetings, project partner sites, and national and international workshops/conferences to present results, and to write reports about progress in the project
+
+Essential Skills and Qualifications:
+- High level of programming skills, including Python knowledge and its relevant libraries
+- Outstanding communication skills and experience working with remote communication tools
+- Experience in research software engineering, including version control, testing and CI
+- Experience and knowledge in the domain of magnetism and/or computational magnetism
+  
+Desired Skills and Qualifications:
+- PhD or equivalent qualifications in Physics, Materials Science, Computational Science, Engineering or a closely related field
+- Experience using micromagnetic simulation tools such as (e.g. Ubermag, OOMMF, mumax3, RSPt, UppASD, ...)
+- Experience and track record of work on open-source projects
+- Experience in machine learning and AI methods, and relevant software libraries (such as Pytorch, Tensorflow, Keras, …)
+- Ability and flexibility to work in an open and collaborative manner with researchers from different domains and to deep-dive into new topics in a short time
+- Experience working with high-performance computing systems
+- Motivation to create new open source products that can help to improve the health of our planet
+
+The positions are subject to availability of third-party funding within the framework of the project MaMMoS. We offer the positions according to the German public pay scale.
+
+**The appointment is for up 24 months, starting as soon as possible, ending December 2027.**
+
+The Max Planck Society strives for gender equality and diversity. We welcome applications from all backgrounds.
+
+The Max-Planck Society is committed to increasing the number of individuals with disabilities in its workforce and therefore encourages applications from such qualified individuals.
+
+Interested candiates are invited to complete the online application form and submit your CV, cover letter, and references or names of referees. In your application, please highlight the specific skills and experiences you bring to the team. The screening of applications and interviews will start from 10 October 2025 and will continue until the positions is filled. For further information please contact Prof. Dr. Hans Fangohr, phone: +49 40 8998-88390, e-mail: hans.fangohr@mpsd.mpg.de, https://cs.mpsd.mpg.de.
+
+Detailed information about the Max Planck Institute for the Structure and Dynamics of Matter can be found at http://www.mpsd.mpg.de.
+
+**The application link and final advert will be published soon.**
+
+
+


### PR DESCRIPTION
I have labelled this 'draft'. The text can be updated to match the final version once we have advertised on the platform where people can submit applications. We can then remove the draft label, and add a link to the submission site and the official advert in that location. 