### PR TITLE
add ontology to MaMMoS main webpage

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -86,7 +86,7 @@ Magnetic materials domain ontology
 
 As part of the MaMMoS project an EMMO-based
 `domain ontology for magnetic materials (MagMO) <https://emmo-repo.github.io/domain-magnetic-materials/>`__
-was created. The development takes place in https://github.com/emmo-repo/domain-magnetic-materials>.
+was created. The development takes place in https://github.com/emmo-repo/domain-magnetic-materials.
 
 The `mammos-entity <https://github.com/mammos-project/mammos-entity>`__ Python package provides a convenient way of annotating raw data with metadata supplied by the ontology (EMMO and MagMO), e.g. by writing metadata-enriched files.
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -81,6 +81,13 @@ documentation:
        (`documentation <https://mammos-project.github.io/mammos>`__)
      - Quantities (values with units).
 
+Magnetic materials domain ontology
+----------------------------------
+
+As part of the MaMMoS project the EMMO-based domain specific ontology
+`Magnetic Materials domain Ontology (MagMO) <https://emmo-repo.github.io/domain-magnetic-materials/>`__
+was created. The development takes place in the `emmo-repo/domain-magnetic-materials repository <https://github.com/emmo-repo/domain-magnetic-materials>`__.
+
 Additional Tools
 ----------------
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -86,7 +86,7 @@ Magnetic materials domain ontology
 
 As part of the MaMMoS project an EMMO-based
 `domain ontology for magnetic materials (MagMO) <https://emmo-repo.github.io/domain-magnetic-materials/>`__
-was created. The development takes place in the `emmo-repo/domain-magnetic-materials repository <https://github.com/emmo-repo/domain-magnetic-materials>`__.
+was created. The development takes place in https://github.com/emmo-repo/domain-magnetic-materials>.
 
 The `mammos-entity <https://github.com/mammos-project/mammos-entity>`__ Python package provides a convenient way of annotating raw data with metadata supplied by the ontology (EMMO and MagMO), e.g. by writing metadata-enriched files.
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -88,7 +88,7 @@ As part of the MaMMoS project an EMMO-based
 `domain ontology for magnetic materials (MagMO) <https://emmo-repo.github.io/domain-magnetic-materials/>`__
 was created. The development takes place in the `emmo-repo/domain-magnetic-materials repository <https://github.com/emmo-repo/domain-magnetic-materials>`__.
 
-The `mammos-entity <https://github.com/mammos-project/mammos-entity>`__ Python package allows operations with entities, such as writing metadata-enriched files, where such metadata is supplied by the ontologies EMMO and MagMO.
+The `mammos-entity <https://github.com/mammos-project/mammos-entity>`__ Python package provides a convenient way of annotating raw data with metadata supplied by the ontology (EMMO and MagMO), e.g. by writing metadata-enriched files.
 
 Additional Tools
 ----------------

--- a/source/index.rst
+++ b/source/index.rst
@@ -84,8 +84,8 @@ documentation:
 Magnetic materials domain ontology
 ----------------------------------
 
-As part of the MaMMoS project the EMMO-based domain specific ontology
-`Magnetic Materials domain Ontology (MagMO) <https://emmo-repo.github.io/domain-magnetic-materials/>`__
+As part of the MaMMoS project an EMMO-based
+`domain ontology for magnetic materials (MagMO) <https://emmo-repo.github.io/domain-magnetic-materials/>`__
 was created. The development takes place in the `emmo-repo/domain-magnetic-materials repository <https://github.com/emmo-repo/domain-magnetic-materials>`__.
 
 The `mammos-entity <https://github.com/mammos-project/mammos-entity>`__ Python package allows operations with entities, such as writing metadata-enriched files, where such metadata is supplied by the ontologies EMMO and MagMO.

--- a/source/index.rst
+++ b/source/index.rst
@@ -88,6 +88,8 @@ As part of the MaMMoS project the EMMO-based domain specific ontology
 `Magnetic Materials domain Ontology (MagMO) <https://emmo-repo.github.io/domain-magnetic-materials/>`__
 was created. The development takes place in the `emmo-repo/domain-magnetic-materials repository <https://github.com/emmo-repo/domain-magnetic-materials>`__.
 
+The `mammos-entity <https://github.com/mammos-project/mammos-entity>`__ Python package allows operations with entities, such as writing metadata-enriched files, where such metadata is supplied by the ontologies EMMO and MagMO.
+
 Additional Tools
 ----------------
 


### PR DESCRIPTION
Close #22 

As suggested in https://github.com/MaMMoS-project/MaMMoS-project.github.io/pull/9#issuecomment-4126218979

Depends on https://github.com/emmo-repo/domain-magnetic-materials/pull/9 (migration from MagneticMaterialsOntology repo to emmo-repo/domain-magnetic-materials)